### PR TITLE
results: update API to use tap-go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     - go get -u github.com/clearlinux/mixer-tools/swupd
     - go get -u github.com/gomodule/redigo/redis
     - go get -u github.com/rafaeljusto/redigomock
+    - go get -u github.com/mndrix/tap-go
     - gometalinter.v2 --install
 
 script:

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -25,6 +25,7 @@ type allFetchFlags struct {
 	version     string
 	bundleURL   string
 	upstreamURL string
+	recursive   bool
 }
 
 var allFlags allFetchFlags
@@ -106,10 +107,11 @@ func init() {
 
 	fetchUpdateCmd.Flags().StringVarP(&allFlags.version, "version", "v", "", "version from which to pull data")
 	fetchUpdateCmd.Flags().StringVarP(&allFlags.upstreamURL, "upstreamurl", "u", "", "URL from which to pull update metadata")
+	fetchUpdateCmd.Flags().BoolVarP(&allFlags.recursive, "recursive", "r", false, "recursively fetch all content referenced in update metadata")
 }
 
 func runFetchAllCmd(cmd *cobra.Command, args []string) {
-	u, err := diva.GetUpstreamInfo(conf, allFlags.upstreamURL, allFlags.version)
+	u, err := diva.GetUpstreamInfo(conf, allFlags.upstreamURL, allFlags.version, allFlags.recursive)
 	if err != nil {
 		helpers.Fail(err)
 	}
@@ -138,7 +140,7 @@ func runFetchBundlesCmd(cmd *cobra.Command, args []string) {
 }
 
 func runFetchRepoCmd(cmd *cobra.Command, args []string) {
-	u, err := diva.GetUpstreamInfo(conf, allFlags.upstreamURL, allFlags.version)
+	u, err := diva.GetUpstreamInfo(conf, allFlags.upstreamURL, allFlags.version, allFlags.recursive)
 	if err != nil {
 		helpers.Fail(err)
 	}
@@ -150,12 +152,17 @@ func runFetchRepoCmd(cmd *cobra.Command, args []string) {
 }
 
 func runFetchUpdateCmd(cmd *cobra.Command, args []string) {
-	u, err := diva.GetUpstreamInfo(conf, allFlags.upstreamURL, allFlags.version)
+	u, err := diva.GetUpstreamInfo(conf, allFlags.upstreamURL, allFlags.version, allFlags.recursive)
 	if err != nil {
 		helpers.Fail(err)
 	}
 
 	err = diva.FetchUpdate(u)
+	if err != nil {
+		helpers.Fail(err)
+	}
+
+	err = diva.FetchUpdateFiles(u)
 	if err != nil {
 		helpers.Fail(err)
 	}

--- a/cmd/pipcheck.go
+++ b/cmd/pipcheck.go
@@ -62,12 +62,6 @@ func runPipCheck(cmd *cobra.Command, args []string) {
 	}
 
 	results := PipCheck(p)
-
-	err := results.Print(os.Stdout)
-	if err != nil {
-		helpers.Fail(err)
-	}
-
 	if results.Failed > 0 {
 		os.Exit(1)
 	}
@@ -75,10 +69,14 @@ func runPipCheck(cmd *cobra.Command, args []string) {
 
 // PipCheck runs 'pip check' in a chroot at path
 func PipCheck(path string) *diva.Results {
-	r := &diva.Results{Name: "pipcheck"}
 	name := "pipcheck"
 	desc := "run pip check in full build root to check for missing python requirements"
+	r := diva.NewSuite(name, desc)
+	r.Header(0)
 	err := helpers.RunCommandSilent("chroot", path, "pip", "check")
-	r.Add(name, desc, err, false)
+	r.Ok(err == nil, desc)
+	if err != nil {
+		r.Diagnostic(err.Error())
+	}
 	return r
 }

--- a/cmd/updatecontent.go
+++ b/cmd/updatecontent.go
@@ -1,0 +1,120 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/clearlinux/diva/diva"
+	"github.com/clearlinux/diva/internal/helpers"
+	"github.com/clearlinux/diva/updatecontent"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	checkCmd.AddCommand(ucCmd)
+	ucCmd.Flags().UintVarP(&ucFlags.version, "version", "v", 0, "version to check")
+	ucCmd.Flags().BoolVarP(&ucFlags.recursive, "recursive", "r", false, "perform complete recursive check")
+}
+
+type ucCmdFlags struct {
+	version   uint
+	recursive bool
+}
+
+var ucFlags ucCmdFlags
+
+var ucCmd = &cobra.Command{
+	Use:   "updatecontent",
+	Short: "Validate update file and pack content",
+	Long: `Validate update content for <version> or latest if --version was not provided.
+Validates that all file and pack content is available and correct and the m
+local configuration and <version>. If --recursive was passed, perform the check
+on all update content reachable through the manifests, otherwise validate only
+the current version.`,
+	Run: runUCCheck,
+}
+
+func runUCCheck(cmd *cobra.Command, args []string) {
+	var err error
+	v := ucFlags.version
+	if v == 0 {
+		v, err = helpers.GetLatestVersion(conf.UpstreamURL)
+		if err != nil {
+			helpers.Fail(err)
+		}
+	}
+
+	results, err := UCCheck(v, ucFlags.recursive)
+	if err != nil {
+		helpers.Fail(err)
+	}
+
+	err = results.Print(os.Stdout)
+	if err != nil {
+		helpers.Fail(err)
+	}
+
+	if results.Failed > 0 {
+		os.Exit(1)
+	}
+}
+
+// UCCheck runs update content checks against manifests and their related file
+// and pack contents
+func UCCheck(version uint, recursive bool) (*diva.Results, error) {
+	r := &diva.Results{Name: "updatecontent"}
+	u := diva.UInfo{Ver: version, URL: conf.UpstreamURL, CacheLoc: conf.Paths.CacheLocation}
+	if !recursive {
+		u.MinVer = version
+	}
+	err := diva.FetchUpdate(u)
+	if err != nil {
+		return r, err
+	}
+
+	err = diva.FetchUpdateFiles(u)
+	if err != nil {
+		return r, err
+	}
+
+	checkManifestHashes(r, u.Ver, u.MinVer)
+	checkFileHashes(r, u.Ver, u.MinVer)
+	checkZeroPacks(r, u.Ver, u.MinVer)
+
+	return r, err
+}
+
+func checkManifestHashes(r *diva.Results, version, minVer uint) {
+	name := "Manifest hashes"
+	desc := "check manifest hashes match hashes listed in MoM"
+	err := updatecontent.CheckManifestHashes(conf.Paths.CacheLocation, version, minVer)
+	r.Add(name, desc, err, false)
+}
+
+func checkFileHashes(r *diva.Results, version, minVer uint) {
+	name := "File hashes"
+	desc := "check file hashes match hashes listed in manifest"
+	err := updatecontent.CheckFileHashes(conf.Paths.CacheLocation, version, minVer)
+	r.Add(name, desc, err, false)
+}
+
+func checkZeroPacks(r *diva.Results, version, minVer uint) {
+	name := "Zero packs"
+	desc := "check zero pack content matches content listed in manifests"
+	err := updatecontent.CheckZeroPacks(conf, version, minVer)
+	r.Add(name, desc, err, false)
+}

--- a/diva/fetch.go
+++ b/diva/fetch.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/clearlinux/diva/internal/config"
 	"github.com/clearlinux/diva/internal/helpers"
@@ -32,12 +33,13 @@ import (
 // cache location
 type UInfo struct {
 	Ver      string
+	MinVer   uint
 	URL      string
 	CacheLoc string
 }
 
 // GetUpstreamInfo populates the UInfo struct and returns it
-func GetUpstreamInfo(conf *config.Config, upstreamURL string, version string) (UInfo, error) {
+func GetUpstreamInfo(conf *config.Config, upstreamURL string, version string, recursive bool) (UInfo, error) {
 	u := UInfo{}
 	if upstreamURL == "" {
 		u.URL = conf.UpstreamURL
@@ -66,6 +68,11 @@ func GetUpstreamInfo(conf *config.Config, upstreamURL string, version string) (U
 	u.Ver = strings.Trim(string(body), "\n")
 	// no support yet for modifying cache location via commandline
 	u.CacheLoc = conf.Paths.CacheLocation
+
+	if !recursive {
+		u.MinVer = u.Ver
+	}
+
 	return u, err
 }
 
@@ -115,7 +122,7 @@ func GetLatestBundles(conf *config.Config, url string) error {
 
 // FetchUpdate downloads manifests from the u.URL server
 func FetchUpdate(u UInfo) error {
-	helpers.PrintBegin("fetching manifests from %s at version %s", u.URL, u.Ver)
+	helpers.PrintBegin("fetching manifests from %s at version %v", u.URL, u.Ver)
 	baseCache := filepath.Join(u.CacheLoc, "update")
 	outMoM := filepath.Join(baseCache, u.Ver, "Manifest.MoM")
 	err := helpers.DownloadManifest(u.URL, u.Ver, "MoM", outMoM)
@@ -128,13 +135,116 @@ func FetchUpdate(u UInfo) error {
 	}
 
 	for i := range mom.Files {
-		ver := fmt.Sprint(mom.Files[i].Version)
-		outMan := filepath.Join(baseCache, ver, "Manifest."+mom.Files[i].Name)
-		err := helpers.DownloadManifest(u.URL, ver, mom.Files[i].Name, outMan)
+		ver := uint(mom.Files[i].Version)
+		if ver < u.MinVer {
+			continue
+		}
+		outMan := filepath.Join(baseCache, fmt.Sprint(ver), "Manifest."+mom.Files[i].Name)
+		_, err := helpers.DownloadManifest(u.URL, fmt.Sprint(ver), mom.Files[i].Name, outMan)
 		if err != nil {
 			return err
 		}
 	}
 	helpers.PrintComplete("manifests cached at %s", baseCache)
+	return nil
+}
+
+type finfo struct {
+	out string
+	url string
+	err error
+}
+
+func getAllFiles(u UInfo) (map[string]finfo, error) {
+	dlFiles := make(map[string]finfo)
+	baseCache := filepath.Join(u.CacheLoc, "update")
+	outMoM := filepath.Join(baseCache, fmt.Sprint(u.Ver), "Manifest.MoM")
+	mom, err := helpers.DownloadManifest(u.URL, u.Ver, "MoM", outMoM)
+	if err != nil {
+		return nil, err
+	}
+
+	// this is fast, no need to parallelize
+	for i := range mom.Files {
+		mv := uint(mom.Files[i].Version)
+		if mv < u.MinVer {
+			continue
+		}
+		baseCache := filepath.Join(u.CacheLoc, "update")
+		outMan := filepath.Join(baseCache, fmt.Sprint(mv), "Manifest."+mom.Files[i].Name)
+		m, err := helpers.DownloadManifest(u.URL, mv, mom.Files[i].Name, outMan)
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range m.Files {
+			if uint(f.Version) < u.MinVer || !f.Present() {
+				continue
+			}
+
+			fURL := fmt.Sprintf("%s/update/%d/files/%s.tar", u.URL, f.Version, f.Hash)
+			fOut := filepath.Join(baseCache, fmt.Sprint(f.Version), "files", f.Hash.String()+".tar")
+			fi := finfo{out: fOut, url: fURL}
+			dlFiles[fOut] = fi
+		}
+	}
+	return dlFiles, nil
+}
+
+// FetchUpdateFiles downloads relevant files for u.Ver from u.URL
+func FetchUpdateFiles(u UInfo) error {
+	helpers.PrintBegin("fetching files from %s at version %d", u.URL, u.Ver)
+	dlFiles, err := getAllFiles(u)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	nworkers := 8
+	wg.Add(nworkers)
+	fChan := make(chan finfo)
+	errChan := make(chan error)
+
+	retried := false
+	for i := 0; i < nworkers; i++ {
+		go func() {
+			defer wg.Done()
+			for f := range fChan {
+				// we already have this file cached
+				if _, err := os.Lstat(strings.TrimSuffix(f.out, ".tar")); err == nil {
+					continue
+				}
+
+				f.err = helpers.TarExtractURL(f.url, f.out)
+				err := os.Remove(f.out)
+				if err != nil {
+					fmt.Println(err)
+				}
+
+				if f.err != nil {
+					fmt.Println(f.err)
+					if !retried {
+						fmt.Println("retrying download...")
+						retried = true
+						i--
+					} else {
+						fmt.Println("unable to download, continuing...")
+						errChan <- f.err
+					}
+				}
+			}
+		}()
+	}
+
+	for f := range dlFiles {
+		fChan <- dlFiles[f]
+	}
+	close(fChan)
+	wg.Wait()
+
+	if len(errChan) > 0 {
+		helpers.PrintComplete("errors downloading %d files", len(errChan))
+	} else {
+		helpers.PrintComplete("files cached at %s", filepath.Join(u.CacheLoc, "update"))
+	}
 	return nil
 }

--- a/diva/fetch.go
+++ b/diva/fetch.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -70,7 +71,12 @@ func GetUpstreamInfo(conf *config.Config, upstreamURL string, version string, re
 	u.CacheLoc = conf.Paths.CacheLocation
 
 	if !recursive {
-		u.MinVer = u.Ver
+		var mv int
+		mv, err = strconv.Atoi(u.Ver)
+		if err != nil {
+			return u, err
+		}
+		u.MinVer = uint(mv)
 	}
 
 	return u, err
@@ -140,7 +146,7 @@ func FetchUpdate(u UInfo) error {
 			continue
 		}
 		outMan := filepath.Join(baseCache, fmt.Sprint(ver), "Manifest."+mom.Files[i].Name)
-		_, err := helpers.DownloadManifest(u.URL, fmt.Sprint(ver), mom.Files[i].Name, outMan)
+		err := helpers.DownloadManifest(u.URL, fmt.Sprint(ver), mom.Files[i].Name, outMan)
 		if err != nil {
 			return err
 		}
@@ -159,7 +165,12 @@ func getAllFiles(u UInfo) (map[string]finfo, error) {
 	dlFiles := make(map[string]finfo)
 	baseCache := filepath.Join(u.CacheLoc, "update")
 	outMoM := filepath.Join(baseCache, fmt.Sprint(u.Ver), "Manifest.MoM")
-	mom, err := helpers.DownloadManifest(u.URL, u.Ver, "MoM", outMoM)
+	err := helpers.DownloadManifest(u.URL, u.Ver, "MoM", outMoM)
+	if err != nil {
+		return nil, err
+	}
+
+	mom, err := swupd.ParseManifestFile(outMoM)
 	if err != nil {
 		return nil, err
 	}
@@ -172,10 +183,16 @@ func getAllFiles(u UInfo) (map[string]finfo, error) {
 		}
 		baseCache := filepath.Join(u.CacheLoc, "update")
 		outMan := filepath.Join(baseCache, fmt.Sprint(mv), "Manifest."+mom.Files[i].Name)
-		m, err := helpers.DownloadManifest(u.URL, mv, mom.Files[i].Name, outMan)
+		err := helpers.DownloadManifest(u.URL, fmt.Sprint(mv), mom.Files[i].Name, outMan)
 		if err != nil {
 			return nil, err
 		}
+
+		m, err := swupd.ParseManifestFile(outMan)
+		if err != nil {
+			return nil, err
+		}
+
 		for _, f := range m.Files {
 			if uint(f.Version) < u.MinVer || !f.Present() {
 				continue
@@ -192,7 +209,7 @@ func getAllFiles(u UInfo) (map[string]finfo, error) {
 
 // FetchUpdateFiles downloads relevant files for u.Ver from u.URL
 func FetchUpdateFiles(u UInfo) error {
-	helpers.PrintBegin("fetching files from %s at version %d", u.URL, u.Ver)
+	helpers.PrintBegin("fetching files from %s at version %v", u.URL, u.Ver)
 	dlFiles, err := getAllFiles(u)
 	if err != nil {
 		return err

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -223,7 +223,12 @@ func TarExtractURL(url, target string) error {
 		return err
 	}
 
-	return RunCommandSilent("tar", "-C", filepath.Dir(target), "-xf", target)
+	return RunCommandSilent(
+		"tar",
+		"--preserve-permissions",
+		"-C", filepath.Dir(target),
+		"-xf", target,
+	)
 }
 
 // PrintBegin prints the beginning of a task

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -233,12 +233,12 @@ func TarExtractURL(url, target string) error {
 
 // PrintBegin prints the beginning of a task
 func PrintBegin(message string, fmts ...interface{}) {
-	fmt.Println(fmt.Sprintf(fmt.Sprintf("--> %s", message), fmts...))
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(fmt.Sprintf("--> %s", message), fmts...))
 }
 
 // PrintComplete prints completion of a task
 func PrintComplete(message string, fmts ...interface{}) {
-	fmt.Println(fmt.Sprintf(fmt.Sprintf("    %s", message), fmts...))
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(fmt.Sprintf("    %s", message), fmts...))
 }
 
 // Fail prints the error and exits the program with an error code

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -20,10 +20,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -73,7 +75,18 @@ func Download(url, filename string) error {
 	}
 
 	// move tempfile to final now that everything else has succeeded
-	return os.Rename(tmpFile, filename)
+	return renameIfNE(tmpFile, filename)
+}
+
+func renameIfNE(src, dst string) error {
+	err := os.Link(src, dst)
+	if err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+
+	return os.Remove(src)
 }
 
 // DownloadFile downloads from url and extracts the file if necessary using the
@@ -192,7 +205,7 @@ func DownloadManifest(baseURL string, version string, component, outF string) er
 	if err != nil {
 		return err
 	}
-	err = tarExtractURL(url, outF)
+	err = TarExtractURL(url, outF)
 	if err != nil {
 		return err
 	}
@@ -200,8 +213,13 @@ func DownloadManifest(baseURL string, version string, component, outF string) er
 	return nil
 }
 
-func tarExtractURL(url, target string) error {
-	if err := Download(url, target); err != nil {
+// TarExtractURL downloads a tar file from a URL and extracts it to target
+func TarExtractURL(url, target string) error {
+	err := os.MkdirAll(filepath.Dir(target), 0777)
+	if err != nil {
+		return err
+	}
+	if err = Download(url, target); err != nil {
 		return err
 	}
 
@@ -222,4 +240,23 @@ func PrintComplete(message string, fmts ...interface{}) {
 func Fail(err error) {
 	fmt.Fprintf(os.Stderr, "%s: ERROR: %s\n", os.Args[0], err)
 	os.Exit(1)
+}
+
+// GetLatestVersion returns the version value at upstreamURL/latest or an error
+// if unable to do so.
+func GetLatestVersion(upstreamURL string) (uint, error) {
+	resp, err := http.Get(upstreamURL + "/latest")
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	vStr := strings.Trim(string(body), "\n")
+	ver, err := strconv.ParseUint(vStr, 10, 32)
+	return uint(ver), err
 }

--- a/updatecontent/check.go
+++ b/updatecontent/check.go
@@ -15,9 +15,9 @@
 package updatecontent
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -30,12 +30,13 @@ import (
 
 // CheckManifestHashes compares manifest hashes against the hashes listed in
 // the MoM for that version
-func CheckManifestHashes(cacheLoc string, version, minVer uint) error {
-	cLoc := filepath.Join(cacheLoc, "update")
+func CheckManifestHashes(c *config.Config, version, minVer uint) (errs []error) {
+	cLoc := filepath.Join(c.Paths.CacheLocation, "update")
 	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
 	MoM, err := swupd.ParseManifestFile(momPath)
 	if err != nil {
-		return err
+		errs = append(errs, err)
+		return
 	}
 	for i := range MoM.Files {
 		if uint(MoM.Files[i].Version) < minVer {
@@ -45,53 +46,81 @@ func CheckManifestHashes(cacheLoc string, version, minVer uint) error {
 			cLoc, fmt.Sprint(MoM.Files[i].Version), "Manifest."+MoM.Files[i].Name)
 		hash, err := swupd.Hashcalc(mPath)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 		if hash != MoM.Files[i].Hash {
-			return fmt.Errorf("%s hash did not match hash listed in %s", mPath, momPath)
+			err = fmt.Errorf("%s hash did not match hash listed in %s", mPath, momPath)
+			errs = append(errs, err)
+			continue
 		}
 	}
-	return nil
+	return
 }
 
-func checkBundleFileHashes(cacheLoc string, m *swupd.Manifest, minVer uint) error {
+func checkBundleFileHashes(cacheLoc string, m *swupd.Manifest, minVer uint) (errs []error) {
+	var wg sync.WaitGroup
+	workers := len(m.Files)
+	wg.Add(workers)
+	fCh := make(chan *swupd.File)
+	eCh := make(chan error)
+
 	cLoc := filepath.Join(cacheLoc, "update")
-	for i := range m.Files {
-		if !m.Files[i].Present() {
-			continue
-		}
-		if uint(m.Files[i].Version) < minVer {
-			continue
-		}
-		fLoc := filepath.Join(
-			cLoc, fmt.Sprint(m.Files[i].Version), "files", m.Files[i].Hash.String())
-		hash, err := swupd.Hashcalc(fLoc)
-		if err != nil {
-			return err
-		}
-		if hash != m.Files[i].Hash {
-			return fmt.Errorf("%s hash did not match hash listed in %s for %s",
-				fLoc, m.Name, m.Files[i].Name)
-		}
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for f := range fCh {
+				if !f.Present() {
+					continue
+				}
+				if uint(f.Version) < minVer {
+					continue
+				}
+				fLoc := filepath.Join(cLoc, fmt.Sprint(f.Version), "files", f.Hash.String())
+				hash, err := swupd.Hashcalc(fLoc)
+				if err != nil {
+					eCh <- err
+					continue
+				}
+				if hash != f.Hash {
+					err = fmt.Errorf("%s hash did not match hash listed in %s for %s",
+						fLoc, m.Name, f.Name)
+					eCh <- err
+					continue
+				}
+			}
+		}()
 	}
 
-	return nil
+	for _, f := range m.Files {
+		fCh <- f
+	}
+	close(fCh)
+	wg.Wait()
+	close(eCh)
+
+	for e := range eCh {
+		errs = append(errs, e)
+	}
+
+	return
 }
 
 // CheckFileHashes checks that the downloaded file content matches the hashes
 // listed in the manifests
-func CheckFileHashes(cacheLoc string, version, minVer uint) error {
-	cLoc := filepath.Join(cacheLoc, "update")
+func CheckFileHashes(c *config.Config, version, minVer uint) (errs []error) {
+	cLoc := filepath.Join(c.Paths.CacheLocation, "update")
 	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
 	MoM, err := swupd.ParseManifestFile(momPath)
 	if err != nil {
-		return err
+		errs = append(errs, err)
+		return
 	}
 	var wg sync.WaitGroup
 	nworkers := len(MoM.Files)
 	wg.Add(nworkers)
 	fChan := make(chan *swupd.File)
-	errChan := make(chan error)
+	errChan := make(chan error, nworkers)
 
 	for i := 0; i < nworkers; i++ {
 		go func() {
@@ -105,9 +134,12 @@ func CheckFileHashes(cacheLoc string, version, minVer uint) error {
 				if err != nil {
 					errChan <- err
 				}
-				err = checkBundleFileHashes(cacheLoc, m, minVer)
-				if err != nil {
-					errChan <- err
+				es := checkBundleFileHashes(c.Paths.CacheLocation, m, minVer)
+				for _, e := range es {
+					errChan <- e
+				}
+				if len(es) > 0 {
+					continue
 				}
 			}
 		}()
@@ -118,25 +150,124 @@ func CheckFileHashes(cacheLoc string, version, minVer uint) error {
 	}
 	close(fChan)
 	wg.Wait()
-	var errs []string
-	if len(errChan) > 0 {
-		for e := range errChan {
-			errs = append(errs, e.Error())
-		}
-		return errors.New(strings.Join(errs, "\n"))
+	close(errChan)
+	for e := range errChan {
+		errs = append(errs, e)
 	}
+	return
+}
+
+func checkBundleFileHashesPack(filesLoc string, m *swupd.Manifest, minVer uint) []error {
+	var wg sync.WaitGroup
+	workers := 4 // have to deal with "too many open files"
+	wg.Add(workers)
+	fCh := make(chan *swupd.File)
+	eCh := make(chan error)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for f := range fCh {
+				if uint(f.Version) < minVer {
+					continue
+				}
+				if !f.Present() {
+					continue
+				}
+				fLoc := filepath.Join(filesLoc, f.Hash.String())
+				hash, err := swupd.Hashcalc(fLoc)
+				if err != nil {
+					eCh <- err
+					continue
+				}
+				if hash != f.Hash {
+					err := fmt.Errorf("%s hash did not match hash listed in %s for %s",
+						fLoc, m.Name, f.Name)
+					eCh <- err
+					continue
+				}
+			}
+		}()
+	}
+
+	for _, f := range m.Files {
+		fCh <- f
+	}
+	close(fCh)
+	wg.Wait()
+	close(eCh)
+
+	var errs []error
+	for e := range eCh {
+		errs = append(errs, e)
+	}
+
+	return errs
+}
+
+// CheckZeroPack validates the zero pack associated with the bundle at the present version
+func CheckZeroPack(c *config.Config, m *swupd.Manifest) (errs []error) {
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("check-zero-pack-%s-%d-", m.Name, m.Header.Version))
+	if err != nil {
+		errs = append(errs, err)
+		return
+	}
+	defer func() {
+		if len(errs) == 0 {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+
+	url := fmt.Sprintf("%s/update/%d/pack-%s-from-0.tar", c.UpstreamURL, m.Header.Version, m.Name)
+	err = helpers.TarExtractURL(url, filepath.Join(tmpDir, fmt.Sprint(m.Header.Version)))
+	if err != nil {
+		errs = append(errs, err)
+		return
+	}
+
+	es := checkBundleFileHashesPack(filepath.Join(tmpDir, "staged"), m, 0)
+	for _, e := range es {
+		errs = append(errs, e)
+	}
+	return
+}
+
+func checkSingleDelta(deltaFile, fromFile, expHash string) error {
+	testFile := fromFile + ".test"
+	err := helpers.RunCommandSilent("bspatch", fromFile, testFile, deltaFile)
+	if err != nil {
+		return err
+	}
+
+	hash, err := swupd.Hashcalc(testFile)
+	if err != nil {
+		return err
+	}
+
+	if hash.String() != expHash {
+		return fmt.Errorf("delta %s produced incorrect hash\nexpected: %s\nproduced: %s",
+			deltaFile, expHash, hash.String())
+	}
+
 	return nil
 }
 
-func checkBundleFileHashesPack(filesLoc string, m *swupd.Manifest, minVer uint) error {
+func checkDeltaPack(c *config.Config, dir string, m *swupd.Manifest) error {
+	deltaTos := make(map[string]uint32)
 	for i := range m.Files {
-		if uint(m.Files[i].Version) < minVer {
+		if m.Files[i].Version != m.Header.Version {
 			continue
 		}
-		fLoc := filepath.Join(filesLoc, m.Files[i].Hash.String())
+		if !m.Files[i].Present() {
+			continue
+		}
+
+		fLoc := filepath.Join(dir, "staged", m.Files[i].Hash.String())
 		hash, err := swupd.Hashcalc(fLoc)
 		if err != nil {
-			return err
+			// check for delta
+			deltaTos[m.Files[i].Hash.String()] = m.Files[i].Version
+			continue
 		}
 		if hash != m.Files[i].Hash {
 			return fmt.Errorf("%s hash did not match hash listed in %s for %s",
@@ -144,49 +275,153 @@ func checkBundleFileHashesPack(filesLoc string, m *swupd.Manifest, minVer uint) 
 		}
 	}
 
+	deltaNames := make(map[string]string)
+	deltaFiles, err := ioutil.ReadDir(filepath.Join(dir, "delta"))
+	if err != nil {
+		return err
+	}
+	for _, d := range deltaFiles {
+		// fromVer-toVer-fromHash-toHash
+		fs := strings.Split(d.Name(), "-")
+		if len(fs) != 4 {
+			continue
+		}
+		deltaNames[fs[3]] = d.Name()
+	}
+
+	for h := range deltaTos {
+		val, ok := deltaNames[h]
+		if !ok {
+			return fmt.Errorf("could not find %s in delta pack at %s", h, dir)
+		}
+		fields := strings.Split(filepath.Base(val), "-")
+		// can expect that len(fields) == 4 due to above check
+		fromV := fields[0]
+		fromH := fields[2]
+		url := fmt.Sprintf("%s/update/%s/files/%s.tar", c.UpstreamURL, fromV, fromH)
+		fromF := filepath.Join(dir, fromH)
+		err = helpers.TarExtractURL(url, fromF)
+		if err != nil {
+			return err
+		}
+		deltaFile := filepath.Join(dir, "delta", val)
+		err = checkSingleDelta(deltaFile, fromF, h)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
-func checkZeroPack(c *config.Config, m *swupd.Manifest) error {
-	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("check-zero-pack-%s-%d", m.Name, m.Header.Version))
-	if err != nil {
-		return err
+// CheckDeltaPacks checks the delta packs for the m bundle
+func CheckDeltaPacks(c *config.Config, m *swupd.Manifest) (errs []error) {
+	vers := make(map[uint32]struct{})
+	var exists = struct{}{}
+	for _, f := range m.Files {
+		vers[f.Version] = exists
 	}
 
-	url := fmt.Sprintf("%s/update/%d/pack-%s-from-0.tar", c.UpstreamURL, m.Header.Version, m.Name)
-	err = helpers.TarExtractURL(url, tmpDir)
-	if err != nil {
-		return err
+	var wg sync.WaitGroup
+	workers := len(vers)
+	wg.Add(workers)
+	vCh := make(chan uint32)
+	errCh := make(chan error)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for v := range vCh {
+				tmpDir, err := ioutil.TempDir("", fmt.Sprintf("check-delta-pack-%s-%d-", m.Name, v))
+				if err != nil {
+					errCh <- err
+					continue
+				}
+				defer func() {
+					_ = os.RemoveAll(tmpDir)
+				}()
+
+				url := fmt.Sprintf("%s/update/%d/pack-%s-from-%d.tar", c.UpstreamURL, m.Header.Version, m.Name, v)
+				err = helpers.TarExtractURL(url, filepath.Join(tmpDir, fmt.Sprint(v)))
+				if err != nil {
+					// assume no delta pack
+					_ = os.RemoveAll(tmpDir)
+					continue
+				}
+
+				err = checkDeltaPack(c, tmpDir, m)
+				if err != nil {
+					errCh <- err
+					continue
+				}
+			}
+		}()
 	}
 
-	return checkBundleFileHashesPack(filepath.Join(tmpDir, "files"), m, 0)
+	for v := range vers {
+		vCh <- v
+	}
+
+	close(vCh)
+	wg.Wait()
+	close(errCh)
+
+	for e := range errCh {
+		errs = append(errs, e)
+	}
+
+	return
 }
 
-// CheckZeroPacks validates the file contents of zero packs against manifest
-// hashes.
-func CheckZeroPacks(c *config.Config, version, minVer uint) error {
+// CheckPacks validates the file contents of packs against manifest hashes
+// using the pack check function pc
+func CheckPacks(c *config.Config, version, minVer uint, pc func(*config.Config, *swupd.Manifest) []error) (errs []error) {
 	cLoc := filepath.Join(c.Paths.CacheLocation, "update")
 	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
 	MoM, err := swupd.ParseManifestFile(momPath)
 	if err != nil {
-		return err
+		errs = append(errs, err)
+		return
 	}
 
-	for i := range MoM.Files {
-		if uint(MoM.Files[i].Version) < minVer {
-			continue
-		}
-		mPath := filepath.Join(
-			cLoc, fmt.Sprint(MoM.Files[i].Version), "Manifest."+MoM.Files[i].Name)
-		m, err := swupd.ParseManifestFile(mPath)
-		if err != nil {
-			return err
-		}
-		err = checkZeroPack(c, m)
-		if err != nil {
-			return nil
-		}
+	var wg sync.WaitGroup
+	workers := 4
+	wg.Add(workers)
+	bCh := make(chan *swupd.File)
+	eCh := make(chan error)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for man := range bCh {
+				if uint(man.Version) < minVer {
+					continue
+				}
+				mPath := filepath.Join(cLoc, fmt.Sprint(man.Version), "Manifest."+man.Name)
+				m, err := swupd.ParseManifestFile(mPath)
+				if err != nil {
+					eCh <- err
+					continue
+				}
+				es := pc(c, m)
+				for _, e := range es {
+					eCh <- e
+				}
+				if len(es) > 0 {
+					continue
+				}
+			}
+		}()
 	}
 
-	return nil
+	for _, b := range MoM.Files {
+		bCh <- b
+	}
+	close(bCh)
+	wg.Wait()
+	close(eCh)
+
+	for e := range eCh {
+		errs = append(errs, e)
+	}
+	return
 }

--- a/updatecontent/check.go
+++ b/updatecontent/check.go
@@ -1,0 +1,192 @@
+// Copyright © 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updatecontent
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/clearlinux/diva/internal/config"
+	"github.com/clearlinux/diva/internal/helpers"
+
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+// CheckManifestHashes compares manifest hashes against the hashes listed in
+// the MoM for that version
+func CheckManifestHashes(cacheLoc string, version, minVer uint) error {
+	cLoc := filepath.Join(cacheLoc, "update")
+	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
+	MoM, err := swupd.ParseManifestFile(momPath)
+	if err != nil {
+		return err
+	}
+	for i := range MoM.Files {
+		if uint(MoM.Files[i].Version) < minVer {
+			continue
+		}
+		mPath := filepath.Join(
+			cLoc, fmt.Sprint(MoM.Files[i].Version), "Manifest."+MoM.Files[i].Name)
+		hash, err := swupd.Hashcalc(mPath)
+		if err != nil {
+			return err
+		}
+		if hash != MoM.Files[i].Hash {
+			return fmt.Errorf("%s hash did not match hash listed in %s", mPath, momPath)
+		}
+	}
+	return nil
+}
+
+func checkBundleFileHashes(cacheLoc string, m *swupd.Manifest, minVer uint) error {
+	cLoc := filepath.Join(cacheLoc, "update")
+	for i := range m.Files {
+		if !m.Files[i].Present() {
+			continue
+		}
+		if uint(m.Files[i].Version) < minVer {
+			continue
+		}
+		fLoc := filepath.Join(
+			cLoc, fmt.Sprint(m.Files[i].Version), "files", m.Files[i].Hash.String())
+		hash, err := swupd.Hashcalc(fLoc)
+		if err != nil {
+			return err
+		}
+		if hash != m.Files[i].Hash {
+			return fmt.Errorf("%s hash did not match hash listed in %s for %s",
+				fLoc, m.Name, m.Files[i].Name)
+		}
+	}
+
+	return nil
+}
+
+// CheckFileHashes checks that the downloaded file content matches the hashes
+// listed in the manifests
+func CheckFileHashes(cacheLoc string, version, minVer uint) error {
+	cLoc := filepath.Join(cacheLoc, "update")
+	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
+	MoM, err := swupd.ParseManifestFile(momPath)
+	if err != nil {
+		return err
+	}
+	var wg sync.WaitGroup
+	nworkers := len(MoM.Files)
+	wg.Add(nworkers)
+	fChan := make(chan *swupd.File)
+	errChan := make(chan error)
+
+	for i := 0; i < nworkers; i++ {
+		go func() {
+			defer wg.Done()
+			for f := range fChan {
+				if uint(f.Version) < minVer {
+					continue
+				}
+				mPath := filepath.Join(cLoc, fmt.Sprint(f.Version), "Manifest."+f.Name)
+				m, err := swupd.ParseManifestFile(mPath)
+				if err != nil {
+					errChan <- err
+				}
+				err = checkBundleFileHashes(cacheLoc, m, minVer)
+				if err != nil {
+					errChan <- err
+				}
+			}
+		}()
+	}
+
+	for i := range MoM.Files {
+		fChan <- MoM.Files[i]
+	}
+	close(fChan)
+	wg.Wait()
+	var errs []string
+	if len(errChan) > 0 {
+		for e := range errChan {
+			errs = append(errs, e.Error())
+		}
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func checkBundleFileHashesPack(filesLoc string, m *swupd.Manifest, minVer uint) error {
+	for i := range m.Files {
+		if uint(m.Files[i].Version) < minVer {
+			continue
+		}
+		fLoc := filepath.Join(filesLoc, m.Files[i].Hash.String())
+		hash, err := swupd.Hashcalc(fLoc)
+		if err != nil {
+			return err
+		}
+		if hash != m.Files[i].Hash {
+			return fmt.Errorf("%s hash did not match hash listed in %s for %s",
+				fLoc, m.Name, m.Files[i].Name)
+		}
+	}
+
+	return nil
+}
+
+func checkZeroPack(c *config.Config, m *swupd.Manifest) error {
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("check-zero-pack-%s-%d", m.Name, m.Header.Version))
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/update/%d/pack-%s-from-0.tar", c.UpstreamURL, m.Header.Version, m.Name)
+	err = helpers.TarExtractURL(url, tmpDir)
+	if err != nil {
+		return err
+	}
+
+	return checkBundleFileHashesPack(filepath.Join(tmpDir, "files"), m, 0)
+}
+
+// CheckZeroPacks validates the file contents of zero packs against manifest
+// hashes.
+func CheckZeroPacks(c *config.Config, version, minVer uint) error {
+	cLoc := filepath.Join(c.Paths.CacheLocation, "update")
+	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
+	MoM, err := swupd.ParseManifestFile(momPath)
+	if err != nil {
+		return err
+	}
+
+	for i := range MoM.Files {
+		if uint(MoM.Files[i].Version) < minVer {
+			continue
+		}
+		mPath := filepath.Join(
+			cLoc, fmt.Sprint(MoM.Files[i].Version), "Manifest."+MoM.Files[i].Name)
+		m, err := swupd.ParseManifestFile(mPath)
+		if err != nil {
+			return err
+		}
+		err = checkZeroPack(c, m)
+		if err != nil {
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/updatecontent/check.go
+++ b/updatecontent/check.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/clearlinux/diva/diva"
 	"github.com/clearlinux/diva/internal/config"
 	"github.com/clearlinux/diva/internal/helpers"
 
@@ -30,13 +31,12 @@ import (
 
 // CheckManifestHashes compares manifest hashes against the hashes listed in
 // the MoM for that version
-func CheckManifestHashes(c *config.Config, version, minVer uint) (errs []error) {
+func CheckManifestHashes(r *diva.Results, c *config.Config, version, minVer uint) error {
 	cLoc := filepath.Join(c.Paths.CacheLocation, "update")
 	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
 	MoM, err := swupd.ParseManifestFile(momPath)
 	if err != nil {
-		errs = append(errs, err)
-		return
+		return err
 	}
 	for i := range MoM.Files {
 		if uint(MoM.Files[i].Version) < minVer {
@@ -46,24 +46,22 @@ func CheckManifestHashes(c *config.Config, version, minVer uint) (errs []error) 
 			cLoc, fmt.Sprint(MoM.Files[i].Version), "Manifest."+MoM.Files[i].Name)
 		hash, err := swupd.Hashcalc(mPath)
 		if err != nil {
-			errs = append(errs, err)
-			continue
+			return err
 		}
-		if hash != MoM.Files[i].Hash {
-			err = fmt.Errorf("%s hash did not match hash listed in %s", mPath, momPath)
-			errs = append(errs, err)
-			continue
-		}
+		desc := fmt.Sprintf("Manifest.%s hash matches hash in MoM", MoM.Files[i].Name)
+		r.Ok(hash == MoM.Files[i].Hash, desc)
 	}
-	return
+
+	return nil
 }
 
-func checkBundleFileHashes(cacheLoc string, m *swupd.Manifest, minVer uint) (errs []error) {
+func checkBundleFileHashes(cacheLoc string, m *swupd.Manifest, minVer uint) ([]string, error) {
 	var wg sync.WaitGroup
 	workers := len(m.Files)
 	wg.Add(workers)
 	fCh := make(chan *swupd.File)
-	eCh := make(chan error)
+	eCh := make(chan error, workers)
+	fails := make(chan string, workers)
 
 	cLoc := filepath.Join(cacheLoc, "update")
 	for i := 0; i < workers; i++ {
@@ -80,41 +78,53 @@ func checkBundleFileHashes(cacheLoc string, m *swupd.Manifest, minVer uint) (err
 				hash, err := swupd.Hashcalc(fLoc)
 				if err != nil {
 					eCh <- err
-					continue
+					break
 				}
 				if hash != f.Hash {
-					err = fmt.Errorf("%s hash did not match hash listed in %s for %s",
-						fLoc, m.Name, f.Name)
-					eCh <- err
-					continue
+					fails <- f.Name
 				}
 			}
 		}()
 	}
 
+	var err error
 	for _, f := range m.Files {
-		fCh <- f
+		select {
+		case fCh <- f:
+		case err = <-eCh:
+			// break on first failure
+			break
+		}
 	}
 	close(fCh)
 	wg.Wait()
-	close(eCh)
+	close(fails)
 
-	for e := range eCh {
-		errs = append(errs, e)
+	if err == nil && len(eCh) > 0 {
+		err = <-eCh
 	}
 
-	return
+	chanLen := len(eCh)
+	for i := 0; i < chanLen; i++ {
+		<-eCh
+	}
+
+	var failures []string
+	for fail := range fails {
+		failures = append(failures, fail)
+	}
+
+	return failures, err
 }
 
 // CheckFileHashes checks that the downloaded file content matches the hashes
 // listed in the manifests
-func CheckFileHashes(c *config.Config, version, minVer uint) (errs []error) {
+func CheckFileHashes(r *diva.Results, c *config.Config, version, minVer uint) error {
 	cLoc := filepath.Join(c.Paths.CacheLocation, "update")
 	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
 	MoM, err := swupd.ParseManifestFile(momPath)
 	if err != nil {
-		errs = append(errs, err)
-		return
+		return err
 	}
 	var wg sync.WaitGroup
 	nworkers := len(MoM.Files)
@@ -130,16 +140,20 @@ func CheckFileHashes(c *config.Config, version, minVer uint) (errs []error) {
 					continue
 				}
 				mPath := filepath.Join(cLoc, fmt.Sprint(f.Version), "Manifest."+f.Name)
-				m, err := swupd.ParseManifestFile(mPath)
-				if err != nil {
-					errChan <- err
-				}
-				es := checkBundleFileHashes(c.Paths.CacheLocation, m, minVer)
-				for _, e := range es {
+				m, e := swupd.ParseManifestFile(mPath)
+				if e != nil {
 					errChan <- e
+					break
 				}
-				if len(es) > 0 {
-					continue
+				failures, e := checkBundleFileHashes(c.Paths.CacheLocation, m, minVer)
+				if e != nil {
+					errChan <- e
+					break
+				}
+				desc := fmt.Sprintf("file hashes for %s bundle match hashes in manifest", m.Name)
+				r.Ok(len(failures) == 0, desc)
+				if len(failures) > 0 {
+					r.Diagnostic("mismatched hashes:\n" + strings.Join(failures, "\n"))
 				}
 			}
 		}()
@@ -147,14 +161,21 @@ func CheckFileHashes(c *config.Config, version, minVer uint) (errs []error) {
 
 	for i := range MoM.Files {
 		fChan <- MoM.Files[i]
+		select {
+		case fChan <- MoM.Files[i]:
+		case err = <-errChan:
+			// break on first failure
+			break
+		}
 	}
 	close(fChan)
 	wg.Wait()
-	close(errChan)
-	for e := range errChan {
-		errs = append(errs, e)
+
+	if err == nil && len(errChan) > 0 {
+		err = <-errChan
 	}
-	return
+
+	return err
 }
 
 func checkBundleFileHashesPack(filesLoc string, m *swupd.Manifest, minVer uint) []error {
@@ -206,30 +227,27 @@ func checkBundleFileHashesPack(filesLoc string, m *swupd.Manifest, minVer uint) 
 }
 
 // CheckZeroPack validates the zero pack associated with the bundle at the present version
-func CheckZeroPack(c *config.Config, m *swupd.Manifest) (errs []error) {
+func CheckZeroPack(c *config.Config, m *swupd.Manifest) ([]string, error) {
 	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("check-zero-pack-%s-%d-", m.Name, m.Header.Version))
 	if err != nil {
-		errs = append(errs, err)
-		return
+		return []string{}, err
 	}
 	defer func() {
-		if len(errs) == 0 {
-			_ = os.RemoveAll(tmpDir)
-		}
+		_ = os.RemoveAll(tmpDir)
 	}()
 
 	url := fmt.Sprintf("%s/update/%d/pack-%s-from-0.tar", c.UpstreamURL, m.Header.Version, m.Name)
 	err = helpers.TarExtractURL(url, filepath.Join(tmpDir, fmt.Sprint(m.Header.Version)))
 	if err != nil {
-		errs = append(errs, err)
-		return
+		return []string{}, err
 	}
 
+	var failures []string
 	es := checkBundleFileHashesPack(filepath.Join(tmpDir, "staged"), m, 0)
 	for _, e := range es {
-		errs = append(errs, e)
+		failures = append(failures, e.Error())
 	}
-	return
+	return failures, nil
 }
 
 func checkSingleDelta(deltaFile, fromFile, expHash string) error {
@@ -314,7 +332,7 @@ func checkDeltaPack(c *config.Config, dir string, m *swupd.Manifest) error {
 }
 
 // CheckDeltaPacks checks the delta packs for the m bundle
-func CheckDeltaPacks(c *config.Config, m *swupd.Manifest) (errs []error) {
+func CheckDeltaPacks(c *config.Config, m *swupd.Manifest) ([]string, error) {
 	vers := make(map[uint32]struct{})
 	var exists = struct{}{}
 	for _, f := range m.Files {
@@ -326,6 +344,7 @@ func CheckDeltaPacks(c *config.Config, m *swupd.Manifest) (errs []error) {
 	wg.Add(workers)
 	vCh := make(chan uint32)
 	errCh := make(chan error)
+	failCh := make(chan string)
 
 	for i := 0; i < workers; i++ {
 		go func() {
@@ -334,7 +353,7 @@ func CheckDeltaPacks(c *config.Config, m *swupd.Manifest) (errs []error) {
 				tmpDir, err := ioutil.TempDir("", fmt.Sprintf("check-delta-pack-%s-%d-", m.Name, v))
 				if err != nil {
 					errCh <- err
-					continue
+					break
 				}
 				defer func() {
 					_ = os.RemoveAll(tmpDir)
@@ -350,37 +369,48 @@ func CheckDeltaPacks(c *config.Config, m *swupd.Manifest) (errs []error) {
 
 				err = checkDeltaPack(c, tmpDir, m)
 				if err != nil {
-					errCh <- err
-					continue
+					failCh <- err.Error()
+					break
 				}
 			}
 		}()
 	}
 
+	var err error
 	for v := range vers {
-		vCh <- v
+		select {
+		case vCh <- v:
+		case err = <-errCh:
+			// break on first failure
+			break
+		}
 	}
 
 	close(vCh)
 	wg.Wait()
 	close(errCh)
+	close(failCh)
 
-	for e := range errCh {
-		errs = append(errs, e)
+	if err == nil && len(errCh) > 0 {
+		err = <-errCh
 	}
 
-	return
+	var fails []string
+	for f := range failCh {
+		fails = append(fails, f)
+	}
+
+	return fails, err
 }
 
 // CheckPacks validates the file contents of packs against manifest hashes
 // using the pack check function pc
-func CheckPacks(c *config.Config, version, minVer uint, pc func(*config.Config, *swupd.Manifest) []error) (errs []error) {
+func CheckPacks(r *diva.Results, c *config.Config, version, minVer uint, delta bool) error {
 	cLoc := filepath.Join(c.Paths.CacheLocation, "update")
 	momPath := filepath.Join(cLoc, fmt.Sprint(version), "Manifest.MoM")
 	MoM, err := swupd.ParseManifestFile(momPath)
 	if err != nil {
-		errs = append(errs, err)
-		return
+		return err
 	}
 
 	var wg sync.WaitGroup
@@ -397,31 +427,48 @@ func CheckPacks(c *config.Config, version, minVer uint, pc func(*config.Config, 
 					continue
 				}
 				mPath := filepath.Join(cLoc, fmt.Sprint(man.Version), "Manifest."+man.Name)
-				m, err := swupd.ParseManifestFile(mPath)
-				if err != nil {
-					eCh <- err
-					continue
-				}
-				es := pc(c, m)
-				for _, e := range es {
+				m, e := swupd.ParseManifestFile(mPath)
+				if e != nil {
 					eCh <- e
+					break
 				}
-				if len(es) > 0 {
-					continue
+				var failures []string
+				var desc string
+				if delta {
+					failures, e = CheckDeltaPacks(c, m)
+					desc = "delta pack content correct for " + m.Name
+				} else {
+					failures, e = CheckZeroPack(c, m)
+					desc = "zero pack content correct for " + m.Name
+				}
+
+				if e != nil {
+					eCh <- e
+					break
+				}
+				r.Ok(len(failures) == 0, desc)
+				if len(failures) > 0 {
+					r.Diagnostic("pack issues:\n" + strings.Join(failures, "\n"))
 				}
 			}
 		}()
 	}
 
 	for _, b := range MoM.Files {
-		bCh <- b
+		select {
+		case bCh <- b:
+		case err = <-eCh:
+			// break on first failure
+			break
+		}
 	}
 	close(bCh)
 	wg.Wait()
 	close(eCh)
 
-	for e := range eCh {
-		errs = append(errs, e)
+	if err == nil && len(eCh) > 0 {
+		err = <-eCh
 	}
-	return
+
+	return err
 }


### PR DESCRIPTION
Update the results API to use tap-go and pass the test object to the
check functions.

Only the last commit is relevant, based on #31 