### PR TITLE
Use imported MoM info in UC check

### DIFF
--- a/bloatcheck/bloatcheck.go
+++ b/bloatcheck/bloatcheck.go
@@ -64,8 +64,8 @@ func GetBundleSize(mInfo pkginfo.ManifestInfo) (map[string]int64, error) {
 
 	var bundleSizes = make(map[string]int64)
 
-	sort.Slice(mInfo.Mom.Files, func(i, j int) bool {
-		return mInfo.Mom.Files[i].Name < mInfo.Mom.Files[j].Name
+	sort.Slice(mInfo.MoM.Files, func(i, j int) bool {
+		return mInfo.MoM.Files[i].Name < mInfo.MoM.Files[j].Name
 	})
 
 	for i := 0; i < bundleWorkers; i++ {

--- a/cmd/updatecontent.go
+++ b/cmd/updatecontent.go
@@ -82,19 +82,19 @@ func UCCheck(m *pkginfo.ManifestInfo) (*diva.Results, error) {
 	r := diva.NewSuite("updatecontent", "check update content for release")
 
 	r.Header(0)
-	err = updatecontent.CheckManifestHashes(r, conf, m.UintVer, m.MinVer)
+	err = updatecontent.CheckManifestHashes(r, conf, m)
 	if err != nil {
 		return r, err
 	}
-	err = updatecontent.CheckFileHashes(r, conf, m.UintVer, m.MinVer)
+	err = updatecontent.CheckFileHashes(r, conf, m)
 	if err != nil {
 		return r, err
 	}
-	err = updatecontent.CheckPacks(r, conf, m.UintVer, m.MinVer, true)
+	err = updatecontent.CheckPacks(r, conf, m, true)
 	if err != nil {
 		return r, err
 	}
-	err = updatecontent.CheckPacks(r, conf, m.UintVer, m.MinVer, false)
+	err = updatecontent.CheckPacks(r, conf, m, false)
 	if err != nil {
 		return r, err
 	}

--- a/pkginfo/load_redis.go
+++ b/pkginfo/load_redis.go
@@ -331,12 +331,12 @@ func getManifestsRedis(c redis.Conn, mInfo *ManifestInfo) error {
 	}
 
 	momKey := fmt.Sprintf("%s%smanifests:MoM", mInfo.Name, mInfo.Version)
-	mInfo.Mom, err = getManifestRedis(c, momKey)
+	mInfo.MoM, err = getManifestRedis(c, momKey)
 	if err != nil {
 		return err
 	}
 
-	for _, mFile := range mInfo.Mom.Files {
+	for _, mFile := range mInfo.MoM.Files {
 		manifestKey := fmt.Sprintf("%s%smanifests:%s", mInfo.Name, fmt.Sprint(mFile.Version), mFile.Name)
 		m, err := getManifestRedis(c, manifestKey)
 		if err != nil {

--- a/pkginfo/types.go
+++ b/pkginfo/types.go
@@ -210,7 +210,7 @@ type ManifestInfo struct {
 	BundleInfo
 	UintVer   uint
 	MinVer    uint
-	Mom       *swupd.Manifest
+	MoM       *swupd.Manifest
 	Manifests map[string]*swupd.Manifest
 }
 


### PR DESCRIPTION
Change mom struct field to be MoM, and use that stored metadata for the checks instead of reading from the cache every time.