### PR TITLE
Fix cert naming to sig

### DIFF
--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -11,42 +11,43 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type certsCmdFlags struct {
+type sigCmdFlags struct {
 	mixName  string
 	version  string
 	latest   bool
 	certpath string
 }
 
-var certFlags certsCmdFlags
+var sigFlags sigCmdFlags
 
 func init() {
-	certsCmd.Flags().StringVarP(&certFlags.mixName, "name", "n", "clear", "name of data group")
-	certsCmd.Flags().StringVarP(&certFlags.version, "version", "v", "0", "version to check")
-	certsCmd.Flags().BoolVar(&certFlags.latest, "latest", false, "get the latest version from upstreamURL")
-	certsCmd.Flags().StringVar(&certFlags.certpath, "certpath", "/usr/share/clear/update-ca/Swupd_Root.pem", "fully qualified path to ca-cert")
+	sigCmd.Flags().StringVarP(&sigFlags.mixName, "name", "n", "clear", "name of data group")
+	sigCmd.Flags().StringVarP(&sigFlags.version, "version", "v", "0", "version to check")
+	sigCmd.Flags().BoolVar(&sigFlags.latest, "latest", false, "get the latest version from upstreamURL")
+	sigCmd.Flags().StringVar(&sigFlags.certpath, "certpath", "/usr/share/clear/update-ca/Swupd_Root.pem", "fully qualified path to ca-cert")
 }
 
-var certsCmd = &cobra.Command{
-	Use:   "certs",
-	Short: "",
-	Long:  ``,
-	Run:   runCheckCerts,
+var sigCmd = &cobra.Command{
+	Use:   "signature",
+	Short: "validates Manifest.MoM with the Manifest.MoM.sig",
+	Long: `validates all of the manifests and their files by validating the
+Manifest.MoM.sig file with the ca-cert`,
+	Run: runCheckCerts,
 }
 
 func runCheckCerts(cmd *cobra.Command, args []string) {
 	r := diva.NewSuite("mom", "Validates mom correctly signed")
 
 	u := config.UInfo{
-		MixName: certFlags.mixName,
-		Ver:     certFlags.version,
-		Latest:  certFlags.latest,
+		MixName: sigFlags.mixName,
+		Ver:     sigFlags.version,
+		Latest:  sigFlags.latest,
 	}
 
 	mInfo, err := pkginfo.NewManifestInfo(conf, &u)
 	helpers.FailIfErr(err)
 
-	err = verifyMoM(r, mInfo.CacheLoc, mInfo.Version, certFlags.certpath)
+	err = verifyMoM(r, mInfo.CacheLoc, mInfo.Version, sigFlags.certpath)
 	helpers.FailIfErr(err)
 
 	if r.Failed > 0 {

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -61,6 +62,13 @@ func verifyMoM(r *diva.Results, baseCache, version, cert string) error {
 
 	mom := filepath.Join(cache, "Manifest.MoM")
 	sig := filepath.Join(cache, "Manifest.MoM.sig")
+
+	_, momExists := os.Stat(mom)
+	_, sigExists := os.Stat(sig)
+	if os.IsNotExist(momExists) || os.IsNotExist(sigExists) {
+		return fmt.Errorf("%s or %s does not exist at %s for version %s",
+			mom, sig, cache, version)
+	}
 
 	err := helpers.RunCommandSilent("openssl", "smime", "-verify", "-in", sig,
 		"-inform", "der", "-content", mom, "-purpose", "any", "-CAfile", cert)

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -31,5 +31,5 @@ func init() {
 	checkCmd.AddCommand(ucCmd)
 	checkCmd.AddCommand(verifyBundlesCmd)
 	checkCmd.AddCommand(rpmFileConflictsCmd)
-	checkCmd.AddCommand(certsCmd)
+	checkCmd.AddCommand(sigCmd)
 }


### PR DESCRIPTION
use the correct terminology; this is checking the validity
of the manifest.MoM.sig file, not the cert. Add check that
the manifest.MoM and manifest.MoM.sig files exist prior to
running the check.

Signed-off-by: gabrielle beyer <gabrielle.n.beyer@intel.com>