### PR TITLE
Update concurrency for updatecontent

### DIFF
--- a/updatecontent/updatecontent.go
+++ b/updatecontent/updatecontent.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -51,8 +52,15 @@ func CheckManifestHashes(r *diva.Results, c *config.Config, mInfo *pkginfo.Manif
 }
 
 func checkBundleFileHashes(cacheLoc string, m *swupd.Manifest, minVer uint) ([]string, error) {
+	var workers int
+	FILECAP := runtime.NumCPU() * 3
+	if len(m.Files) <= FILECAP {
+		workers = len(m.Files)
+	} else {
+		workers = FILECAP
+	}
+
 	var wg sync.WaitGroup
-	workers := len(m.Files)
 	wg.Add(workers)
 	fCh := make(chan *swupd.File)
 	eCh := make(chan error, workers)


### PR DESCRIPTION
We can't use a Go routine for each file because swupd.Hashcalc() calls
os.Open() on each file passed to it, which can quickly overflow the max
FD limit. This patch clamps it to the number of CPUs * 3, or the number
of files to process, whichever is smaller. Further testing should be done
if this shows to be a bottleneck.

Fixes issue #82

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>